### PR TITLE
Add width & height to img tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@
                 <picture>
                   <source srcset="assets/88x31s/jxl/cybersecurity.jxl" type="image/jxl">
                   <source srcset="assets/88x31s/avif/cybersecurity.avif" type="image/avif">
-                  <img loading="lazy" src="assets/88x31s/png/cybersecurity.png"
+                  <img width="88" height="31" loading="lazy" src="assets/88x31s/png/cybersecurity.png"
                     alt="Link to an IBM article describing what Cybersecurity even is!">
                 </picture>
               </a>
@@ -108,7 +108,7 @@
                 <picture>
                   <source srcset="assets/88x31s/jxl/eu.jxl" type="image/jxl">
                   <source srcset="assets/88x31s/avif/eu.avif" type="image/avif">
-                  <img loading="lazy" src="assets/88x31s/png/eu.png" alt="Link to find out more about the EU!">
+                  <img width="88" height="31" loading="lazy" src="assets/88x31s/png/eu.png" alt="Link to find out more about the EU!">
                 </picture>
               </a>
             </div>
@@ -123,14 +123,14 @@
             <picture>
               <source srcset="assets/88x31s/jxl/debian.jxl" type="image/jxl">
               <source srcset="assets/88x31s/avif/debian.avif" type="image/avif">
-              <img loading="lazy" src="assets/88x31s/png/debian.png" alt="Link to Debian!">
+              <img width="88" height="31" loading="lazy" src="assets/88x31s/png/debian.png" alt="Link to Debian!">
             </picture>
           </a>
           <a class="eeto" href="https://www.gnu.org/licenses/quick-guide-gplv3.html">
             <picture>
               <source srcset="assets/88x31s/jxl/gpl.jxl" type="image/jxl">
               <source srcset="assets/88x31s/avif/gpl.avif" type="image/avif">
-              <img loading="lazy" src="assets/88x31s/png/gpl.png"
+              <img width="88" height="31" loading="lazy" src="assets/88x31s/png/gpl.png"
                 alt="Link to learn more about the GNU Public License!">
             </picture>
           </a>
@@ -158,14 +158,14 @@
               <picture>
                 <source srcset="assets/88x31s/jxl/yesterweb.jxl" type="image/jxl">
                 <source srcset="assets/88x31s/avif/yesterweb.avif" type="image/avif">
-                <img loading="lazy" src="assets/88x31s/png/yesterweb.png" alt="Link to the Yesterweb Organization.">
+                <img width="88" height="31" loading="lazy" src="assets/88x31s/png/yesterweb.png" alt="Link to the Yesterweb Organization.">
               </picture>
             </a>
             <a href="https://nekoweb.org/" class="eeto">
               <picture>
                 <source srcset="assets/88x31s/jxl/nekoweb.jxl" type="image/jxl">
                 <source srcset="assets/88x31s/avif/nekoweb.avif" type="image/avif">
-                <img loading="lazy" src="assets/88x31s/gif/nekoweb.gif"
+                <img width="88" height="31" loading="lazy" src="assets/88x31s/gif/nekoweb.gif"
                   alt="Link to Nekoweb - you can make your own site!">
               </picture>
             </a>
@@ -181,7 +181,7 @@
               <picture>
                 <source srcset="assets/88x31s/jxl/libsoc.jxl" type="image/jxl">
                 <source srcset="assets/88x31s/avif/libsoc.avif" type="image/avif">
-                <img loading="lazy" src="assets/88x31s/png/libsoc.png"
+                <img width="88" height="31" loading="lazy" src="assets/88x31s/png/libsoc.png"
                   alt="Link for more information about Libertarian Socialism.">
               </picture>
             </a>
@@ -189,7 +189,7 @@
               <picture>
                 <source srcset="assets/88x31s/jxl/letscrushcapitalism.jxl" type="image/jxl">
                 <source srcset="assets/88x31s/avif/letscrushcapitalism.avif" type="image/avif">
-                <img loading="lazy" src="assets/88x31s/png/letscrushcapitalism.png"
+                <img width="88" height="31" loading="lazy" src="assets/88x31s/png/letscrushcapitalism.png"
                   alt="Link for more information about Anti-capitalism.">
               </picture>
             </a>
@@ -204,7 +204,7 @@
               <picture>
                 <source srcset="assets/88x31s/jxl/green.jxl" type="image/jxl">
                 <source srcset="assets/88x31s/avif/green.avif" type="image/avif">
-                <img loading="lazy" src="assets/88x31s/png/green.png"
+                <img width="88" height="31" loading="lazy" src="assets/88x31s/png/green.png"
                   alt="Link for more information about Green politics.">
               </picture>
             </a>
@@ -212,7 +212,7 @@
               <picture>
                 <source srcset="assets/88x31s/jxl/piracy.jxl" type="image/jxl">
                 <source srcset="assets/88x31s/avif/piracy.avif" type="image/avif">
-                <img loading="lazy" src="assets/88x31s/png/piracy.png"
+                <img width="88" height="31" loading="lazy" src="assets/88x31s/png/piracy.png"
                   alt="Link for more information about Pirate Politics">
               </picture>
             </a>
@@ -224,7 +224,7 @@
             <picture>
               <source srcset="assets/88x31s/jxl/agnosticism.jxl" type="image/jxl">
               <source srcset="assets/88x31s/avif/agnosticism.avif" type="image/avif">
-              <img loading="lazy" src="assets/88x31s/png/agnosticism.png"
+              <img width="88" height="31" loading="lazy" src="assets/88x31s/png/agnosticism.png"
                 alt="Link for more information about agnosticism.">
             </picture>
           </a>
@@ -244,7 +244,7 @@
                   <picture>
                     <source srcset="assets/88x31s/jxl/amen.jxl" type="image/jxl">
                     <source srcset="assets/88x31s/avif/amen.avif" type="image/avif">
-                    <img loading="lazy" src="assets/88x31s/png/amen.png"
+                    <img width="88" height="31" loading="lazy" src="assets/88x31s/png/amen.png"
                       alt="Link to the popular Amen Break sample used in most Breakcore songs.">
                   </picture>
                 </a>
@@ -257,7 +257,7 @@
                   <picture>
                     <source srcset="assets/88x31s/jxl/venetiansnares.jxl" type="image/jxl">
                     <source srcset="assets/88x31s/avif/venetiansnares.avif" type="image/avif">
-                    <img loading="lazy" src="assets/88x31s/png/venetiansnares.png"
+                    <img width="88" height="31" loading="lazy" src="assets/88x31s/png/venetiansnares.png"
                       alt="Link to Venetian Snares' Bandcamp">
                   </picture>
                 </a>
@@ -265,7 +265,7 @@
                   <picture>
                     <source srcset="assets/88x31s/jxl/shitmat.jxl" type="image/jxl">
                     <source srcset="assets/88x31s/avif/shitmat.avif" type="image/avif">
-                    <img loading="lazy" src="assets/88x31s/png/shitmat.png" alt="Link to the Shitmat's Neocities page.">
+                    <img width="88" height="31" loading="lazy" src="assets/88x31s/png/shitmat.png" alt="Link to the Shitmat's Neocities page.">
                   </picture>
                 </a>
               </div>
@@ -278,14 +278,14 @@
                   <picture>
                     <source srcset="assets/88x31s/jxl/bye2.jxl" type="image/jxl">
                     <source srcset="assets/88x31s/avif/bye2.avif" type="image/avif">
-                    <img loading="lazy" src="assets/88x31s/png/bye2.png" alt="Link to bye2's awesome website!">
+                    <img width="88" height="31" loading="lazy" src="assets/88x31s/png/bye2.png" alt="Link to bye2's awesome website!">
                   </picture>
                 </a>
                 <a href="https://machin3gir1.com" class="eeto">
                   <picture>
                     <source srcset="assets/88x31s/jxl/machinegirl.jxl" type="image/jxl">
                     <source srcset="assets/88x31s/avif/machinegirl.avif" type="image/avif">
-                    <img loading="lazy" src="assets/88x31s/gif/machinegirl.gif"
+                    <img width="88" height="31" loading="lazy" src="assets/88x31s/gif/machinegirl.gif"
                       alt="Link to Machine Girl's project website.">
                   </picture>
                 </a>
@@ -302,14 +302,14 @@
                   <picture>
                     <source srcset="assets/88x31s/jxl/squarepusher.jxl" type="image/jxl">
                     <source srcset="assets/88x31s/avif/squarepusher.avif" type="image/avif">
-                    <img loading="lazy" src="assets/88x31s/png/squarepusher.png" alt="Link to Squarepusher's website.">
+                    <img width="88" height="31" loading="lazy" src="assets/88x31s/png/squarepusher.png" alt="Link to Squarepusher's website.">
                   </picture>
                 </a>
                 <a href="https://www.laurenbousfield.com/" class="eeto">
                   <picture>
                     <source srcset="assets/88x31s/jxl/ndad.jxl" type="image/jxl">
                     <source srcset="assets/88x31s/avif/ndad.avif" type="image/avif">
-                    <img loading="lazy" src="assets/88x31s/png/ndad.png"
+                    <img width="88" height="31" loading="lazy" src="assets/88x31s/png/ndad.png"
                       alt="Link to Lauren Bousfield's website (creator of Nero's Day at Disneyland).">
                   </picture>
                 </a>
@@ -317,14 +317,14 @@
                   <picture>
                     <source srcset="assets/88x31s/jxl/metaroom.jxl" type="image/jxl">
                     <source srcset="assets/88x31s/avif/metaroom.avif" type="image/avif">
-                    <img loading="lazy" src="assets/88x31s/png/metaroom.png" alt="Link to Metaroom's Bandcamp.">
+                    <img width="88" height="31" loading="lazy" src="assets/88x31s/png/metaroom.png" alt="Link to Metaroom's Bandcamp.">
                   </picture>
                 </a>
                 <a href="https://rorynearly20s.bandcamp.com/" class="eeto">
                   <picture>
                     <source srcset="assets/88x31s/jxl/roryinearly20s.jxl" type="image/jxl">
                     <source srcset="assets/88x31s/avif/roryinearly20s.avif" type="image/avif">
-                    <img loading="lazy" src="assets/88x31s/png/roryinearly20s.png"
+                    <img width="88" height="31" loading="lazy" src="assets/88x31s/png/roryinearly20s.png"
                       alt="Link to Rory In Early 20s's Bandcamp.">
                   </picture>
                 </a>
@@ -332,28 +332,28 @@
                   <picture>
                     <source srcset="assets/88x31s/jxl/vertigoaway.jxl" type="image/jxl">
                     <source srcset="assets/88x31s/avif/vertigoaway.avif" type="image/avif">
-                    <img loading="lazy" src="assets/88x31s/png/vertigoaway.png" alt="Link to Vertigoaway's website.">
+                    <img width="88" height="31" loading="lazy" src="assets/88x31s/png/vertigoaway.png" alt="Link to Vertigoaway's website.">
                   </picture>
                 </a>
                 <a href="https://musicbrainz.org/artist/97635c6a-0178-4827-924f-dda795c34820" class="eeto">
                   <picture>
                     <source srcset="assets/88x31s/jxl/emray.jxl" type="image/jxl">
                     <source srcset="assets/88x31s/avif/emray.avif" type="image/avif">
-                    <img loading="lazy" src="assets/88x31s/png/emray.png" alt="Link to Emray's Musicbrainz listing.">
+                    <img width="88" height="31" loading="lazy" src="assets/88x31s/png/emray.png" alt="Link to Emray's Musicbrainz listing.">
                   </picture>
                 </a>
                 <a href="https://femtanyl.bandcamp.com/" class="eeto">
                   <picture>
                     <source srcset="assets/88x31s/jxl/femtanyl.jxl" type="image/jxl">
                     <source srcset="assets/88x31s/avif/femtanyl.avif" type="image/avif">
-                    <img loading="lazy" src="assets/88x31s/png/femtanyl.png" alt="Link to Femtanyl's Bandcamp.">
+                    <img width="88" height="31" loading="lazy" src="assets/88x31s/png/femtanyl.png" alt="Link to Femtanyl's Bandcamp.">
                   </picture>
                 </a>
                 <a href="https://romdom.bandcamp.com/" class="eeto">
                   <picture>
                     <source srcset="assets/88x31s/jxl/romdom.jxl" type="image/jxl">
                     <source srcset="assets/88x31s/avif/romdom.avif" type="image/avif">
-                    <img loading="lazy" src="assets/88x31s/png/romdom.png" alt="Link to Romdom's Bandcamp.">
+                    <img width="88" height="31" loading="lazy" src="assets/88x31s/png/romdom.png" alt="Link to Romdom's Bandcamp.">
                   </picture>
                 </a>
               </div>
@@ -368,7 +368,7 @@
                     <picture>
                       <source srcset="assets/88x31s/jxl/aphex.jxl" type="image/jxl">
                       <source srcset="assets/88x31s/avif/aphex.avif" type="image/avif">
-                      <img loading="lazy" src="assets/88x31s/png/aphex.png"
+                      <img width="88" height="31" loading="lazy" src="assets/88x31s/png/aphex.png"
                         alt="Link to Aphex Twin's site... Fun fact, as I'm writing this, I am listening to his songs!">
                     </picture>
                   </a>
@@ -381,7 +381,7 @@
                   <picture>
                     <source srcset="assets/88x31s/jxl/diabarha.jxl" type="image/jxl">
                     <source srcset="assets/88x31s/avif/diabarha.avif" type="image/avif">
-                    <img loading="lazy" src="assets/88x31s/png/diabarha.png"
+                    <img width="88" height="31" loading="lazy" src="assets/88x31s/png/diabarha.png"
                       alt="Link to Diabarha's neat music center webpage.">
                   </picture>
                 </a>
@@ -389,7 +389,7 @@
                   <picture>
                     <source srcset="assets/88x31s/jxl/kobaryo.jxl" type="image/jxl">
                     <source srcset="assets/88x31s/avif/kobaryo.avif" type="image/avif">
-                    <img loading="lazy" src="assets/88x31s/png/kobaryo.png" alt="Link to Kobaryo's website.">
+                    <img width="88" height="31" loading="lazy" src="assets/88x31s/png/kobaryo.png" alt="Link to Kobaryo's website.">
                   </picture>
                 </a>
               </div>
@@ -401,7 +401,7 @@
                   <picture>
                     <source srcset="assets/88x31s/jxl/windows96.jxl" type="image/jxl">
                     <source srcset="assets/88x31s/avif/windows96.avif" type="image/avif">
-                    <img loading="lazy" src="assets/88x31s/png/windows96.png"
+                    <img width="88" height="31" loading="lazy" src="assets/88x31s/png/windows96.png"
                       alt="Link to Windows 96's / Gavriel's website.">
                   </picture>
                 </a>
@@ -409,14 +409,14 @@
                   <picture>
                     <source srcset="assets/88x31s/jxl/fakear.jxl" type="image/jxl">
                     <source srcset="assets/88x31s/avif/fakear.avif" type="image/avif">
-                    <img loading="lazy" src="assets/88x31s/png/fakear.png" alt="Link to Fakear's Bandcamp.">
+                    <img width="88" height="31" loading="lazy" src="assets/88x31s/png/fakear.png" alt="Link to Fakear's Bandcamp.">
                   </picture>
                 </a>
                 <a href="https://emancipatormusic.com/" class="eeto">
                   <picture>
                     <source srcset="assets/88x31s/jxl/emancipator.jxl" type="image/jxl">
                     <source srcset="assets/88x31s/avif/emancipator.avif" type="image/avif">
-                    <img loading="lazy" src="assets/88x31s/png/emancipator.png" alt="Link to Emancipator's website.">
+                    <img width="88" height="31" loading="lazy" src="assets/88x31s/png/emancipator.png" alt="Link to Emancipator's website.">
                   </picture>
                 </a>
               </div>
@@ -427,7 +427,7 @@
                 <picture>
                   <source srcset="assets/88x31s/jxl/venetiansnares.jxl" type="image/jxl">
                   <source srcset="assets/88x31s/avif/venetiansnares.avif" type="image/avif">
-                  <img loading="lazy" src="assets/88x31s/png/venetiansnares.png"
+                  <img width="88" height="31" loading="lazy" src="assets/88x31s/png/venetiansnares.png"
                     alt="Link to Venetian Snares' Bandcamp">
                 </picture>
               </a>
@@ -439,7 +439,7 @@
                 <picture>
                   <source srcset="assets/88x31s/jxl/myhalf.jxl" type="image/jxl">
                   <source srcset="assets/88x31s/avif/myhalf.avif" type="image/avif">
-                  <img loading="lazy" src="assets/88x31s/png/myhalf.png"
+                  <img width="88" height="31" loading="lazy" src="assets/88x31s/png/myhalf.png"
                     alt="Link to My Half on Venetian Snares' bandcamp!">
                 </picture>
               </a>
@@ -461,7 +461,7 @@
               <picture>
                 <source srcset="assets/88x31s/jxl/pepsi.jxl" type="image/jxl">
                 <source srcset="assets/88x31s/avif/pepsi.avif" type="image/avif">
-                <img loading="lazy" src="assets/88x31s/png/pepsi.png" alt="Link to the Pepsi Man song!">
+                <img width="88" height="31" loading="lazy" src="assets/88x31s/png/pepsi.png" alt="Link to the Pepsi Man song!">
               </picture>
             </a>
           </div>
@@ -499,7 +499,7 @@
                 <picture>
                   <source srcset="assets/88x31s/jxl/rust.jxl" type="image/jxl">
                   <source srcset="assets/88x31s/avif/rust.avif" type="image/avif">
-                  <img loading="lazy" src="assets/88x31s/png/rust.png"
+                  <img width="88" height="31" loading="lazy" src="assets/88x31s/png/rust.png"
                     alt="Link to find out more about Rust (the programming language)">
                 </picture>
               </a>
@@ -510,7 +510,7 @@
                 <picture>
                   <source srcset="assets/88x31s/jxl/javascript.jxl" type="image/jxl">
                   <source srcset="assets/88x31s/avif/javascript.avif" type="image/avif">
-                  <img loading="lazy" src="assets/88x31s/png/javascript.png"
+                  <img width="88" height="31" loading="lazy" src="assets/88x31s/png/javascript.png"
                     alt="Link to find out more about Javascript!">
                 </picture>
               </a>
@@ -520,7 +520,7 @@
                 <picture>
                   <source srcset="assets/88x31s/jxl/bash.jxl" type="image/jxl">
                   <source srcset="assets/88x31s/avif/bash.avif" type="image/avif">
-                  <img loading="lazy" src="assets/88x31s/png/bash.png" alt="Link to find out more about Bash!">
+                  <img width="88" height="31" loading="lazy" src="assets/88x31s/png/bash.png" alt="Link to find out more about Bash!">
                 </picture>
               </a>
               <p>or scripting with Bash!</p>
@@ -537,21 +537,21 @@
               <picture>
                 <source srcset="assets/88x31s/jxl/graphic_design.jxl" type="image/jxl">
                 <source srcset="assets/88x31s/avif/graphic_design.avif" type="image/avif">
-                <img loading="lazy" src="assets/88x31s/png/graphic_design.png" alt="Graphic design is my passion!">
+                <img width="88" height="31" loading="lazy" src="assets/88x31s/png/graphic_design.png" alt="Graphic design is my passion!">
               </picture>
             </a>
             <a href="https://www.gimp.org/" class="eeto">
               <picture>
                 <source srcset="assets/88x31s/jxl/gimp.jxl" type="image/jxl">
                 <source srcset="assets/88x31s/avif/gimp.avif" type="image/avif">
-                <img loading="lazy" src="assets/88x31s/png/gimp.png" alt="I use GIMP!">
+                <img width="88" height="31" loading="lazy" src="assets/88x31s/png/gimp.png" alt="I use GIMP!">
               </picture>
             </a>
             <a href="https://www.a11yproject.com/" class="eeto">
               <picture>
                 <source srcset="assets/88x31s/jxl/a11y.jxl" type="image/jxl">
                 <source srcset="assets/88x31s/avif/a11y.avif" type="image/avif">
-                <img loading="lazy" src="assets/88x31s/png/a11y.png" alt="Become an a11y now!">
+                <img width="88" height="31" loading="lazy" src="assets/88x31s/png/a11y.png" alt="Become an a11y now!">
               </picture>
             </a>
           </div>
@@ -568,7 +568,7 @@
                 <picture>
                   <source srcset="assets/88x31s/jxl/onzecki.jxl" type="image/jxl">
                   <source srcset="assets/88x31s/avif/onzecki.avif" type="image/avif">
-                  <img loading="lazy" src="assets/88x31s/png/onzecki.png" alt="Image of my button." class="my-icon">
+                  <img width="88" height="31" loading="lazy" src="assets/88x31s/png/onzecki.png" alt="Image of my button." class="my-icon">
                 </picture>
               </div>
               <div class="showcase-item">
@@ -578,7 +578,7 @@
                   <picture>
                     <source srcset="assets/88x31s/jxl/rb.jxl" type="image/jxl">
                     <source srcset="assets/88x31s/avif/rb.avif" type="image/avif">
-                    <img loading="lazy" src="assets/88x31s/png/rb.png" alt="Link to Rocket Bowl's League history.">
+                    <img width="88" height="31" loading="lazy" src="assets/88x31s/png/rb.png" alt="Link to Rocket Bowl's League history.">
                   </picture>
                 </a>
               </div>
@@ -599,7 +599,7 @@
               <picture>
                 <source srcset="assets/88x31s/jxl/rl.jxl" type="image/jxl">
                 <source srcset="assets/88x31s/avif/rl.avif" type="image/avif">
-                <img loading="lazy" src="assets/88x31s/png/rl.png" alt="Link to Rocket League's official website.">
+                <img width="88" height="31" loading="lazy" src="assets/88x31s/png/rl.png" alt="Link to Rocket League's official website.">
               </picture>
             </a>
             <p>
@@ -665,7 +665,7 @@
             <picture>
               <source srcset="assets/88x31s/jxl/mail.jxl" type="image/jxl">
               <source srcset="assets/88x31s/avif/mail.avif" type="image/avif">
-              <img loading="lazy" src="assets/88x31s/png/mail.png" alt="Mail!">
+              <img width="88" height="31" loading="lazy" src="assets/88x31s/png/mail.png" alt="Mail!">
             </picture>
           </a>
         </div>
@@ -678,7 +678,7 @@
             <picture>
               <source srcset="assets/88x31s/jxl/bluesky.jxl" type="image/jxl">
               <source srcset="assets/88x31s/avif/bluesky.avif" type="image/avif">
-              <img loading="lazy" src="assets/88x31s/png/bluesky.png" alt="Link to my Bluesky account!">
+              <img width="88" height="31" loading="lazy" src="assets/88x31s/png/bluesky.png" alt="Link to my Bluesky account!">
             </picture>
           </a>
         </div>
@@ -691,7 +691,7 @@
             <picture>
               <source srcset="assets/88x31s/jxl/f0rest.jxl" type="image/jxl">
               <source srcset="assets/88x31s/avif/f0rest.avif" type="image/avif">
-              <img loading="lazy" src="assets/88x31s/png/f0rest.png"
+              <img width="88" height="31" loading="lazy" src="assets/88x31s/png/f0rest.png"
                 alt="Link to my Matrix instance host - f0rest, hosted by j0 from j0.lol!">
             </picture>
           </a>
@@ -699,7 +699,7 @@
             <picture>
               <source srcset="assets/88x31s/jxl/matrix.jxl" type="image/jxl">
               <source srcset="assets/88x31s/avif/matrix.avif" type="image/avif">
-              <img loading="lazy" src="assets/88x31s/png/matrix.png" alt="Link to the Matrix project homepage!">
+              <img width="88" height="31" loading="lazy" src="assets/88x31s/png/matrix.png" alt="Link to the Matrix project homepage!">
             </picture>
           </a>
         </div>
@@ -714,7 +714,7 @@
             <picture>
               <source srcset="assets/88x31s/jxl/fediverse.jxl" type="image/jxl">
               <source srcset="assets/88x31s/avif/fediverse.avif" type="image/avif">
-              <img loading="lazy" src="assets/88x31s/gif/fediverse.gif"
+              <img width="88" height="31" loading="lazy" src="assets/88x31s/gif/fediverse.gif"
                 alt="Link for more information about the fediverse!">
             </picture>
           </a>
@@ -734,7 +734,7 @@
               <picture>
                 <source srcset="assets/88x31s/jxl/monero.jxl" type="image/jxl">
                 <source srcset="assets/88x31s/avif/monero.avif" type="image/avif">
-                <img loading="lazy" src="assets/88x31s/png/monero.png" alt="Here's more information about Monero!">
+                <img width="88" height="31" loading="lazy" src="assets/88x31s/png/monero.png" alt="Here's more information about Monero!">
               </picture>
             </a>
           </div>
@@ -747,7 +747,7 @@
               <picture>
                 <source srcset="assets/88x31s/jxl/liberapay.jxl" type="image/jxl">
                 <source srcset="assets/88x31s/avif/liberapay.avif" type="image/avif">
-                <img loading="lazy" src="assets/88x31s/png/liberapay.png" alt="Liberapay Icon!">
+                <img width="88" height="31" loading="lazy" src="assets/88x31s/png/liberapay.png" alt="Liberapay Icon!">
               </picture>
             </a>
           </div>
@@ -765,140 +765,140 @@
               <picture>
                 <source srcset="assets/88x31s/jxl/fleepy.jxl" type="image/jxl">
                 <source srcset="assets/88x31s/avif/fleepy.avif" type="image/avif">
-                <img loading="lazy" src="assets/88x31s/png/fleepy.png" alt="Fleepy's Site!">
+                <img width="88" height="31" loading="lazy" src="assets/88x31s/png/fleepy.png" alt="Fleepy's Site!">
               </picture>
             </a>
             <a data-neko="true" href="https://noelle.df1.dev/" class="eeto">
               <picture>
                 <source srcset="assets/88x31s/jxl/noelle.jxl" type="image/jxl">
                 <source srcset="assets/88x31s/avif/noelle.avif" type="image/avif">
-                <img loading="lazy" src="assets/88x31s/png/noelle.png" alt="Noelle's Site!">
+                <img width="88" height="31" loading="lazy" src="assets/88x31s/png/noelle.png" alt="Noelle's Site!">
               </picture>
             </a>
             <a data-neko="true" href="https://sad.ovh" class="eeto">
               <picture>
                 <source srcset="assets/88x31s/jxl/sad.ovh.jxl" type="image/jxl">
                 <source srcset="assets/88x31s/avif/sad.ovh.avif" type="image/avif">
-                <img loading="lazy" src="assets/88x31s/png/sad.ovh.png" alt="Sophie's (sad.ovh) site!">
+                <img width="88" height="31" loading="lazy" src="assets/88x31s/png/sad.ovh.png" alt="Sophie's (sad.ovh) site!">
               </picture>
             </a>
             <a href="https://lenooby09.github.io" class="eeto">
               <picture>
                 <source srcset="assets/88x31s/jxl/lenooby09.jxl" type="image/jxl">
                 <source srcset="assets/88x31s/avif/lenooby09.avif" type="image/avif">
-                <img loading="lazy" src="assets/88x31s/png/lenooby09.png" alt="lenooby09's site!">
+                <img width="88" height="31" loading="lazy" src="assets/88x31s/png/lenooby09.png" alt="lenooby09's site!">
               </picture>
             </a>
             <a href="https://meow-d.github.io" class="eeto">
               <picture>
                 <source srcset="assets/88x31s/jxl/meow_d.jxl" type="image/jxl">
                 <source srcset="assets/88x31s/avif/meow_d.avif" type="image/avif">
-                <img loading="lazy" src="assets/88x31s/png/meow_d.png" alt="meow_d's site!">
+                <img width="88" height="31" loading="lazy" src="assets/88x31s/png/meow_d.png" alt="meow_d's site!">
               </picture>
             </a>
             <a href="https://moosyu.nekoweb.org/pages/links/" class="eeto">
               <picture>
                 <source srcset="assets/88x31s/jxl/moosyu.jxl" type="image/jxl">
                 <source srcset="assets/88x31s/avif/moosyu.avif" type="image/avif">
-                <img loading="lazy" src="assets/88x31s/gif/moosyu.gif" alt="Moosyu's site!">
+                <img width="88" height="31" loading="lazy" src="assets/88x31s/gif/moosyu.gif" alt="Moosyu's site!">
               </picture>
             </a>
             <a href="https://dylan.at" class="eeto">
               <picture>
                 <source srcset="assets/88x31s/jxl/dylan.at.jxl" type="image/jxl">
                 <source srcset="assets/88x31s/avif/dylan.at.avif" type="image/avif">
-                <img loading="lazy" src="assets/88x31s/png/dylan.at.png" alt="Dylan's site!">
+                <img width="88" height="31" loading="lazy" src="assets/88x31s/png/dylan.at.png" alt="Dylan's site!">
               </picture>
             </a>
             <a href="https://j0.lol" class="eeto">
               <picture>
                 <source srcset="assets/88x31s/jxl/j0.jxl" type="image/jxl">
                 <source srcset="assets/88x31s/avif/j0.avif" type="image/avif">
-                <img loading="lazy" src="assets/88x31s/gif/j0.gif" alt="j0's site!">
+                <img width="88" height="31" loading="lazy" src="assets/88x31s/gif/j0.gif" alt="j0's site!">
               </picture>
             </a>
             <a href="https://espi.me" class="eeto">
               <picture>
                 <source srcset="assets/88x31s/jxl/espi.jxl" type="image/jxl">
                 <source srcset="assets/88x31s/avif/espi.avif" type="image/avif">
-                <img loading="lazy" src="assets/88x31s/png/espi.png" alt="espi's site!">
+                <img width="88" height="31" loading="lazy" src="assets/88x31s/png/espi.png" alt="espi's site!">
               </picture>
             </a>
             <a href="https://soap.systems" class="eeto">
               <picture>
                 <source srcset="assets/88x31s/jxl/soap.jxl" type="image/jxl">
                 <source srcset="assets/88x31s/avif/soap.avif" type="image/avif">
-                <img loading="lazy" src="assets/88x31s/png/soap.png" alt="Soap's site!">
+                <img width="88" height="31" loading="lazy" src="assets/88x31s/png/soap.png" alt="Soap's site!">
               </picture>
             </a>
             <a href="https://spax.zone" class="eeto">
               <picture>
                 <source srcset="assets/88x31s/jxl/spaxdotzone.jxl" type="image/jxl">
                 <source srcset="assets/88x31s/avif/spaxdotzone.avif" type="image/avif">
-                <img loading="lazy" src="assets/88x31s/gif/spaxdotzone.gif" alt="Spax's site!">
+                <img width="88" height="31" loading="lazy" src="assets/88x31s/gif/spaxdotzone.gif" alt="Spax's site!">
               </picture>
             </a>
             <a href="https://koldinium.com" class="eeto">
               <picture>
                 <source srcset="assets/88x31s/jxl/kodin.jxl" type="image/jxl">
                 <source srcset="assets/88x31s/avif/kodin.avif" type="image/avif">
-                <img loading="lazy" src="assets/88x31s/gif/kodin.gif" alt="Koldinium's site!">
+                <img width="88" height="31" loading="lazy" src="assets/88x31s/gif/kodin.gif" alt="Koldinium's site!">
               </picture>
             </a>
             <a href="https://buh.moe" class="eeto">
               <picture>
                 <source srcset="assets/88x31s/jxl/amemoia.jxl" type="image/jxl">
                 <source srcset="assets/88x31s/avif/amemoia.avif" type="image/avif">
-                <img loading="lazy" src="assets/88x31s/png/amemoia.png" alt="Amemoia's site!">
+                <img width="88" height="31" loading="lazy" src="assets/88x31s/png/amemoia.png" alt="Amemoia's site!">
               </picture>
             </a>
             <a href="https://girlthi.ng/~thermia/" class="eeto">
               <picture>
                 <source srcset="assets/88x31s/jxl/thermia.jxl" type="image/jxl">
                 <source srcset="assets/88x31s/avif/thermia.avif" type="image/avif">
-                <img loading="lazy" src="assets/88x31s/gif/thermia.gif" alt="Tess's site!">
+                <img width="88" height="31" loading="lazy" src="assets/88x31s/gif/thermia.gif" alt="Tess's site!">
               </picture>
             </a>
             <a href="https://witchy.mom" class="eeto">
               <picture>
                 <source srcset="assets/88x31s/jxl/elaina.jxl" type="image/jxl">
                 <source srcset="assets/88x31s/avif/elaina.avif" type="image/avif">
-                <img loading="lazy" src="assets/88x31s/gif/elaina.gif" alt="Elaina's site!">
+                <img width="88" height="31" loading="lazy" src="assets/88x31s/gif/elaina.gif" alt="Elaina's site!">
               </picture>
             </a>
             <a href="https://danii.fi" class="eeto">
               <picture>
                 <source srcset="assets/88x31s/jxl/daniifi.jxl" type="image/jxl">
                 <source srcset="assets/88x31s/avif/daniifi.avif" type="image/avif">
-                <img loading="lazy" src="assets/88x31s/png/daniifi.png" alt="Danii's site!">
+                <img width="88" height="31" loading="lazy" src="assets/88x31s/png/daniifi.png" alt="Danii's site!">
               </picture>
             </a>
             <a href="https://nanoshinono.me" class="eeto">
               <picture>
                 <source srcset="assets/88x31s/jxl/prefetcher.jxl" type="image/jxl">
                 <source srcset="assets/88x31s/avif/prefetcher.avif" type="image/avif">
-                <img loading="lazy" src="assets/88x31s/gif/prefetcher.gif" alt="Prefetcher's site!">
+                <img width="88" height="31" loading="lazy" src="assets/88x31s/gif/prefetcher.gif" alt="Prefetcher's site!">
               </picture>
             </a>
             <a href="https://aria.coffee" class="eeto">
               <picture>
                 <source srcset="assets/88x31s/jxl/aria.jxl" type="image/jxl">
                 <source srcset="assets/88x31s/avif/aria.avif" type="image/avif">
-                <img loading="lazy" src="assets/88x31s/gif/aria.gif" alt="Aria's site!">
+                <img width="88" height="31" loading="lazy" src="assets/88x31s/gif/aria.gif" alt="Aria's site!">
               </picture>
             </a>
             <a href="https://alyxia.dev" class="eeto">
               <picture>
                 <source srcset="assets/88x31s/jxl/alyxia.jxl" type="image/jxl">
                 <source srcset="assets/88x31s/avif/alyxia.avif" type="image/avif">
-                <img loading="lazy" src="assets/88x31s/png/alyxia.png" alt="Alyxia's site!">
+                <img width="88" height="31" loading="lazy" src="assets/88x31s/png/alyxia.png" alt="Alyxia's site!">
               </picture>
             </a>
             <a href="https://itzzen.net" class="eeto">
               <picture>
                 <source srcset="assets/88x31s/jxl/itzzennet.jxl" type="image/jxl">
                 <source srcset="assets/88x31s/avif/itzzennet.avif" type="image/avif">
-                <img loading="lazy" src="assets/88x31s/png/itzzennet.png" alt="Allissa's site!">
+                <img width="88" height="31" loading="lazy" src="assets/88x31s/png/itzzennet.png" alt="Allissa's site!">
               </picture>
             </a>
           </div>
@@ -915,28 +915,28 @@
               <picture>
                 <source srcset="assets/88x31s/jxl/1920x1080.jxl" type="image/jxl">
                 <source srcset="assets/88x31s/avif/1920x1080.avif" type="image/avif">
-                <img loading="lazy" src="assets/88x31s/png/1920x1080.png" alt="This site is best viewed at 1080p">
+                <img width="88" height="31" loading="lazy" src="assets/88x31s/png/1920x1080.png" alt="This site is best viewed at 1080p">
               </picture>
             </a>
             <a href="https://en.wikipedia.org/wiki/Computer_monitor" class="eeto">
               <picture>
                 <source srcset="assets/88x31s/jxl/monitor.jxl" type="image/jxl">
                 <source srcset="assets/88x31s/avif/monitor.avif" type="image/avif">
-                <img loading="lazy" src="assets/88x31s/png/monitor.png" alt="This site is best viewed with a monitor">
+                <img width="88" height="31" loading="lazy" src="assets/88x31s/png/monitor.png" alt="This site is best viewed with a monitor">
               </picture>
             </a>
             <a href="https://lynx.browser.org/" class="eeto">
               <picture>
                 <source srcset="assets/88x31s/jxl/lynx.jxl" type="image/jxl">
                 <source srcset="assets/88x31s/avif/lynx.avif" type="image/avif">
-                <img loading="lazy" src="assets/88x31s/png/lynx.png" alt="This site fully supports the Lynx browser.">
+                <img width="88" height="31" loading="lazy" src="assets/88x31s/png/lynx.png" alt="This site fully supports the Lynx browser.">
               </picture>
             </a>
             <a href="https://en.wikipedia.org/wiki/HTTP_cookie" class="eeto">
               <picture>
                 <source srcset="assets/88x31s/jxl/cookiefree.jxl" type="image/jxl">
                 <source srcset="assets/88x31s/avif/cookiefree.avif" type="image/avif">
-                <img loading="lazy" src="assets/88x31s/png/cookiefree.png"
+                <img width="88" height="31" loading="lazy" src="assets/88x31s/png/cookiefree.png"
                   alt="This site does not use cookies whatsoever!">
               </picture>
             </a>
@@ -944,7 +944,7 @@
               <picture>
                 <source srcset="assets/88x31s/jxl/handcoded.jxl" type="image/jxl">
                 <source srcset="assets/88x31s/avif/handcoded.avif" type="image/avif">
-                <img loading="lazy" src="assets/88x31s/gif/handcoded.gif"
+                <img width="88" height="31" loading="lazy" src="assets/88x31s/gif/handcoded.gif"
                   alt="This website is completely handcoded. Say no to AI!">
               </picture>
             </a>
@@ -952,7 +952,7 @@
               <picture>
                 <source srcset="assets/88x31s/jxl/testedonfirefox.jxl" type="image/jxl">
                 <source srcset="assets/88x31s/avif/testedonfirefox.avif" type="image/avif">
-                <img loading="lazy" src="assets/88x31s/gif/testedonfirefox.gif"
+                <img width="88" height="31" loading="lazy" src="assets/88x31s/gif/testedonfirefox.gif"
                   alt="This website was tested on Firefox.">
               </picture>
             </a>
@@ -960,21 +960,21 @@
               <picture>
                 <source srcset="assets/88x31s/jxl/caddy.jxl" type="image/jxl">
                 <source srcset="assets/88x31s/avif/caddy.avif" type="image/avif">
-                <img loading="lazy" src="assets/88x31s/png/caddy.png" alt="Served using the Caddy HTTP server!">
+                <img width="88" height="31" loading="lazy" src="assets/88x31s/png/caddy.png" alt="Served using the Caddy HTTP server!">
               </picture>
             </a>
             <a href="https://contabo.com" class="eeto">
               <picture>
                 <source srcset="assets/88x31s/jxl/contabo.jxl" type="image/jxl">
                 <source srcset="assets/88x31s/avif/contabo.avif" type="image/avif">
-                <img loading="lazy" src="assets/88x31s/png/contabo.png" alt="Hosted on Contabo!">
+                <img width="88" height="31" loading="lazy" src="assets/88x31s/png/contabo.png" alt="Hosted on Contabo!">
               </picture>
             </a>
             <a href="https://brainmade.org" class="eeto">
               <picture>
                 <source srcset="assets/88x31s/jxl/brainmade.jxl" type="image/jxl">
                 <source srcset="assets/88x31s/avif/brainmade.avif" type="image/avif">
-                <img loading="lazy" src="assets/88x31s/png/brainmade.png"
+                <img width="88" height="31" loading="lazy" src="assets/88x31s/png/brainmade.png"
                   alt="This site is Brainmade! (Visit the website to find out more.)">
               </picture>
             </a>
@@ -982,14 +982,14 @@
               <picture>
                 <source srcset="assets/88x31s/jxl/zen.jxl" type="image/jxl">
                 <source srcset="assets/88x31s/avif/zen.avif" type="image/avif">
-                <img loading="lazy" src="assets/88x31s/png/zen.png" alt="I use the Zen browser! Check it out here.">
+                <img width="88" height="31" loading="lazy" src="assets/88x31s/png/zen.png" alt="I use the Zen browser! Check it out here.">
               </picture>
             </a>
             <a href="https://mullvad.com" class="eeto">
               <picture>
                 <source srcset="assets/88x31s/jxl/mullvad.jxl" type="image/jxl">
                 <source srcset="assets/88x31s/avif/mullvad.avif" type="image/avif">
-                <img loading="lazy" src="assets/88x31s/png/mullvad.png"
+                <img width="88" height="31" loading="lazy" src="assets/88x31s/png/mullvad.png"
                   alt="This site is sponsored by- Just kidding. I like Mullvad VPN, go check it out!">
               </picture>
             </a>
@@ -999,14 +999,14 @@
             <picture>
               <source srcset="assets/88x31s/jxl/onzecki.jxl" type="image/jxl">
               <source srcset="assets/88x31s/avif/onzecki.avif" type="image/avif">
-              <img loading="lazy" src="assets/88x31s/png/onzecki.png" alt="Image of my button." class="my-icon">
+              <img width="88" height="31" loading="lazy" src="assets/88x31s/png/onzecki.png" alt="Image of my button." class="my-icon">
             </picture>
             <a class="eeto flex-column" href="https://tekeye.uk/computer_history/powered-by">
               <p>Here's a link describing what they are!</p>
               <picture>
                 <source srcset="assets/88x31s/jxl/88by31.jxl" type="image/jxl">
                 <source srcset="assets/88x31s/avif/88by31.avif" type="image/avif">
-                <img loading="lazy" src="assets/88x31s/png/88by31.png" style="align-self: center"
+                <img width="88" height="31" loading="lazy" src="assets/88x31s/png/88by31.png" style="align-self: center"
                   alt="Image example of an 88x31 button.">
               </picture>
             </a>
@@ -1015,7 +1015,7 @@
               <picture>
                 <source srcset="assets/88x31s/jxl/eightyeightthirtyone.jxl" type="image/jxl">
                 <source srcset="assets/88x31s/avif/eightyeightthirtyone.avif" type="image/avif">
-                <img loading="lazy" src="assets/88x31s/png/eightyeightthirtyone.png"
+                <img width="88" height="31" loading="lazy" src="assets/88x31s/png/eightyeightthirtyone.png"
                   alt="Link to eightyeightthirty.one's visualization of the 88x31 universe.">
               </picture>
             </a>
@@ -1042,7 +1042,7 @@
               <picture>
                 <source srcset="assets/88x31s/jxl/free.jxl" type="image/jxl">
                 <source srcset="assets/88x31s/avif/free.avif" type="image/avif">
-                <img loading="lazy" src="assets/88x31s/gif/free.gif" alt="Link to Free's site.">
+                <img width="88" height="31" loading="lazy" src="assets/88x31s/gif/free.gif" alt="Link to Free's site.">
               </picture>
             </a>
           </div>
@@ -1063,7 +1063,7 @@
       <picture>
         <source srcset="assets/88x31s/jxl/cc-by-sa.jxl" type="image/jxl">
         <source srcset="assets/88x31s/avif/cc-by-sa.avif" type="image/avif">
-        <img loading="lazy" src="assets/88x31s/png/cc-by-sa.png"
+        <img width="88" height="31" loading="lazy" src="assets/88x31s/png/cc-by-sa.png"
           alt="This site is licensed under the CC-BY-SA 4.0 license.">
       </picture>
     </a>


### PR DESCRIPTION
Since all images on the page are 88x31 images it makes sense to add their side to ensure no strange layout shifts or lazy loading issues on wildly slow connections.


1. https://web.dev/articles/browser-level-image-lazy-loading#dimension-attributes

While I'm here for this patch since 88x31 images are typically made to be pixel art and not entirely smooth adding `style="image-rendering: pixelated;"` could provide a better experience for those zooming in on a larger monitor but that is a lot more design preference than a standard.